### PR TITLE
Adjust When Spring Security is Loaded

### DIFF
--- a/mvc-freemarker/src/main/java/com/example/demo/DemoApplicationInitializer.java
+++ b/mvc-freemarker/src/main/java/com/example/demo/DemoApplicationInitializer.java
@@ -14,19 +14,18 @@ public class DemoApplicationInitializer extends AbstractAnnotationConfigDispatch
 
     @Override
     protected Class<?>[] getRootConfigClasses() {
+        return null;
+    }
+
+    @Override
+    protected Class<?>[] getServletConfigClasses() {
         return new Class[]{
                 AppConfig.class,
                 Jackson2ObjectMapperConfig.class,
                 DataSourceConfig.class,
                 DataJdbcConfig.class,
                 JdbcConfig.class,
-                SecurityConfig.class
-        };
-    }
-
-    @Override
-    protected Class<?>[] getServletConfigClasses() {
-        return new Class[]{
+                SecurityConfig.class,
                 WebConfig.class
         };
     }


### PR DESCRIPTION
By placing it as part of the Servlet Config, it isn't loaded via a programmatic listener by Spring, thus allowing it to use the ServletRegistration API. While the 6.2 release addresses this by deferring those checks til runtime, having them available at startup will provide a performance benefit as well as the benefit of knowing at startup time if there is an insecure configuration to be corrected.

Related to spring-projects/spring-security#13794